### PR TITLE
Remove unnecessary 'to:' key from allow dns network policy

### DIFF
--- a/course-content/cluster-setup/network-policies/default-deny/default-deny-allow-dns.yaml
+++ b/course-content/cluster-setup/network-policies/default-deny/default-deny-allow-dns.yaml
@@ -11,9 +11,8 @@ spec:
   - Egress
   - Ingress
   egress:
-  - to:
-    ports:
-      - port: 53
-        protocol: TCP
-      - port: 53
-        protocol: UDP
+  - ports:
+    - port: 53
+      protocol: TCP
+    - port: 53
+      protocol: UDP


### PR DESCRIPTION
In `course-content/cluster-setup/network-policies/default-deny/default-deny-allow-dns.yaml`
there is a `to:` key (no value). `kubectl apply` ignores it. So it works, but it can be confusing.

Signed-off-by: Nikhil Thomas <nikhilthomas1@gmail.com>