### PR TITLE
Added apt update before the installs

### DIFF
--- a/cluster-setup/latest/install_master.sh
+++ b/cluster-setup/latest/install_master.sh
@@ -3,6 +3,7 @@
 # Source: http://kubernetes.io/docs/getting-started-guides/kubeadm/
 
 ### setup terminal
+apt-get update
 apt-get install -y bash-completion binutils
 echo 'colorscheme ron' >> ~/.vimrc
 echo 'set tabstop=2' >> ~/.vimrc


### PR DESCRIPTION
Trying to fix the missing packages issue.

```
Err:1 http://security.ubuntu.com/ubuntu bionic-updates/main amd64 binutils-common amd64 2.30-21ubuntu1~18.04.4
  404  Not Found [IP: 35.201.199.33 80]
Ign:4 http://asia-south1.gce.archive.ubuntu.com/ubuntu bionic-updates/main amd64 binutils amd64 2.30-21ubuntu1~18.04.4
Err:2 http://security.ubuntu.com/ubuntu bionic-updates/main amd64 libbinutils amd64 2.30-21ubuntu1~18.04.4
  404  Not Found [IP: 35.201.199.33 80]
Err:3 http://security.ubuntu.com/ubuntu bionic-updates/main amd64 binutils-x86-64-linux-gnu amd64 2.30-21ubuntu1~18.04.4
  404  Not Found [IP: 35.201.199.33 80]
Err:4 http://security.ubuntu.com/ubuntu bionic-updates/main amd64 binutils amd64 2.30-21ubuntu1~18.04.4
  404  Not Found [IP: 35.201.199.33 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/b/binutils/binutils-common_2.30-21ubuntu1~18.04.4_amd64.deb  404  Not Found [IP: 35.201.199.33 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/b/binutils/libbinutils_2.30-21ubuntu1~18.04.4_amd64.deb  404  Not Found [IP: 35.201.199.33 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/b/binutils/binutils-x86-64-linux-gnu_2.30-21ubuntu1~18.04.4_amd64.deb  404  Not Found [IP: 35.201.199.33 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/b/binutils/binutils_2.30-21ubuntu1~18.04.4_amd64.deb  404  Not Found [IP: 35.201.199.33 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```