### PR TITLE
Disable swap & remove existing swap partitions

### DIFF
--- a/cluster-setup/latest/install_master.sh
+++ b/cluster-setup/latest/install_master.sh
@@ -15,6 +15,9 @@ echo 'alias c=clear' >> ~/.bashrc
 echo 'complete -F __start_kubectl k' >> ~/.bashrc
 sed -i '1s/^/force_color_prompt=yes\n/' ~/.bashrc
 
+### disable linux swap space
+swapoff -a 
+sed -i '/ swap / s/^\(.*\)$/#\1/g' /etc/fstab
 
 ### install k8s and docker
 apt-get remove -y docker.io kubelet kubeadm kubectl kubernetes-cni

--- a/cluster-setup/latest/install_master.sh
+++ b/cluster-setup/latest/install_master.sh
@@ -15,7 +15,7 @@ echo 'alias c=clear' >> ~/.bashrc
 echo 'complete -F __start_kubectl k' >> ~/.bashrc
 sed -i '1s/^/force_color_prompt=yes\n/' ~/.bashrc
 
-### disable linux swap space
+### disable linux swap and remove any existing swap partitions
 swapoff -a 
 sed -i '/ swap / s/^\(.*\)$/#\1/g' /etc/fstab
 

--- a/cluster-setup/latest/install_worker.sh
+++ b/cluster-setup/latest/install_worker.sh
@@ -15,6 +15,9 @@ echo 'alias c=clear' >> ~/.bashrc
 echo 'complete -F __start_kubectl k' >> ~/.bashrc
 sed -i '1s/^/force_color_prompt=yes\n/' ~/.bashrc
 
+### disable linux swap space
+swapoff -a 
+sed -i '/ swap / s/^\(.*\)$/#\1/g' /etc/fstab
 
 ### install k8s and docker
 apt-get remove -y docker.io kubelet kubeadm kubectl kubernetes-cni

--- a/cluster-setup/latest/install_worker.sh
+++ b/cluster-setup/latest/install_worker.sh
@@ -15,7 +15,7 @@ echo 'alias c=clear' >> ~/.bashrc
 echo 'complete -F __start_kubectl k' >> ~/.bashrc
 sed -i '1s/^/force_color_prompt=yes\n/' ~/.bashrc
 
-### disable linux swap space
+### disable linux swap and remove any existing swap partitions
 swapoff -a 
 sed -i '/ swap / s/^\(.*\)$/#\1/g' /etc/fstab
 


### PR DESCRIPTION
The [Kubernetes official documentation](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/) for installing `kubeadm` states: 

> You **MUST** disable swap in order for the kubelet to work properly.

Running the `install_master.sh` script on the `cks-master` node, with a fresh installation of  `ubuntu-18.04.5-live-server-amd64.iso`, fails as `swap` is enabled by default:

```
...
[init] Using Kubernetes version: v1.21.0
[preflight] Running pre-flight checks
error execution phase preflight: [preflight] Some fatal errors occurred:
        [ERROR Swap]: running with swap on is not supported. Please disable swap
[preflight] If you know what you are doing, you can make a check non-fatal with `--ignore-preflight-errors=...`
To see the stack trace of this error execute with --v=5 or higher
```

Also, attempting to join the `cks-worker` node, with a fresh installation of  `ubuntu-18.04.5-live-server-amd64.iso`, to the cluster fails as `swap` is enabled by default:

```
root@cks-worker:~# kubeadm join 192.168.x.x:6443 --token <token> --discovery-token-ca-cert-hash sha256:<hash>
[preflight] Running pre-flight checks
error execution phase preflight: [preflight] Some fatal errors occurred:
        [ERROR Swap]: running with swap on is not supported. Please disable swap
[preflight] If you know what you are doing, you can make a check non-fatal with `--ignore-preflight-errors=...`
To see the stack trace of this error execute with --v=5 or higher
```

This PR is to disable `swap` and remove any existing swap partitions as part of the `install_master.sh` and `install_worker.sh` scripts. 

