### PR TITLE
use \s in sed command instead of space so it handles both spaces and …

### DIFF
--- a/cluster-setup/latest/install_master.sh
+++ b/cluster-setup/latest/install_master.sh
@@ -23,7 +23,7 @@ sed -i '1s/^/force_color_prompt=yes\n/' ~/.bashrc
 
 ### disable linux swap and remove any existing swap partitions
 swapoff -a
-sed -i '/ swap / s/^\(.*\)$/#\1/g' /etc/fstab
+sed -i '/\sswap\s/ s/^\(.*\)$/#\1/g' /etc/fstab
 
 
 ### remove packages

--- a/cluster-setup/latest/install_worker.sh
+++ b/cluster-setup/latest/install_worker.sh
@@ -23,7 +23,7 @@ sed -i '1s/^/force_color_prompt=yes\n/' ~/.bashrc
 
 ### disable linux swap and remove any existing swap partitions
 swapoff -a
-sed -i '/ swap / s/^\(.*\)$/#\1/g' /etc/fstab
+sed -i '/\sswap\s/ s/^\(.*\)$/#\1/g' /etc/fstab
 
 
 ### remove packages


### PR DESCRIPTION
Current install scripts don't correctly disable swap in /etc/fstab if "swap" is fstab uses tabs rather than spaces.  Use \s instead of ' ' in sed command so that it will work correctly.