### PR TITLE
prevent unattended-upgrades from breaking cluster

### DIFF
--- a/cluster-setup/latest/install_master.sh
+++ b/cluster-setup/latest/install_master.sh
@@ -31,6 +31,8 @@ kubeadm reset -f || true
 crictl rm --force $(crictl ps -a -q) || true
 apt-mark unhold kubelet kubeadm kubectl kubernetes-cni || true
 apt-get remove -y docker.io containerd kubelet kubeadm kubectl kubernetes-cni || true
+# unattended upgrades are a bad idea on a k8s node, especially if an "apt-mark hold" isn't done on the k8s packages
+apt-get remove -y unattended-upgrades || true
 apt-get autoremove -y
 systemctl daemon-reload
 
@@ -146,7 +148,7 @@ sed -i 's/ghcr.io\/weaveworks\/launcher/docker.io\/weaveworks/g' weave.yaml
 kubectl -f weave.yaml apply
 rm weave.yaml
 
-apt-mark unhold kubelet kubeadm kubectl kubernetes-cni
+# apt-mark unhold kubelet kubeadm kubectl kubernetes-cni
 
 
 # etcdctl

--- a/cluster-setup/latest/install_worker.sh
+++ b/cluster-setup/latest/install_worker.sh
@@ -31,6 +31,8 @@ kubeadm reset -f || true
 crictl rm --force $(crictl ps -a -q) || true
 apt-mark unhold kubelet kubeadm kubectl kubernetes-cni || true
 apt-get remove -y docker.io containerd kubelet kubeadm kubectl kubernetes-cni || true
+# unattended upgrades are a bad idea on a k8s node, especially if an "apt-mark hold" isn't done on the k8s packages$
+apt-get remove -y unattended-upgrades || true$
 apt-get autoremove -y
 systemctl daemon-reload
 
@@ -137,7 +139,7 @@ kubeadm reset -f
 systemctl daemon-reload
 service kubelet start
 
-apt-mark unhold kubelet kubeadm kubectl kubernetes-cni
+# apt-mark unhold kubelet kubeadm kubectl kubernetes-cni
 
 echo
 echo "EXECUTE ON MASTER: kubeadm token create --print-join-command --ttl 0"


### PR DESCRIPTION
My cluster installed with these scripts was broken by the combination of unattended-upgrades (which is installed and enabled by default) running and the scripts having an "apt-mark unhold" for the K8s packages near the bottom of the script.

Allowing the unattended-upgrade of the k8s packages without performing a proper cluster setup is unpredicatable at best and likely to break cluster and should be prevented.

Adding a "Unattended-Upgrade::Package-Blacklist" to the unattended-upgrades configuration is probably a more correct way to prevent this issue and what I would do if using a configuration management system, but just disabling instead is the easiest solution.

https://manpages.ubuntu.com/manpages/bionic/man8/unattended-upgrade.8.html

