### PR TITLE
add yq/jq to cluster install scripts 

### DIFF
--- a/cluster-setup/latest/install_master.sh
+++ b/cluster-setup/latest/install_master.sh
@@ -33,6 +33,11 @@ echo 'complete -F __start_kubectl k' >> ~/.bashrc
 sed -i '1s/^/force_color_prompt=yes\n/' ~/.bashrc
 
 
+### additional command-line tools present in CKS exam environment (https://docs.linuxfoundation.org/tc-docs/certification/important-instructions-cks)
+apt-get install -y jq
+snap install yq
+
+
 ### disable linux swap and remove any existing swap partitions
 swapoff -a
 sed -i '/\sswap\s/ s/^\(.*\)$/#\1/g' /etc/fstab

--- a/cluster-setup/latest/install_worker.sh
+++ b/cluster-setup/latest/install_worker.sh
@@ -33,6 +33,11 @@ echo 'complete -F __start_kubectl k' >> ~/.bashrc
 sed -i '1s/^/force_color_prompt=yes\n/' ~/.bashrc
 
 
+### additional command-line tools present in CKS exam environment (https://docs.linuxfoundation.org/tc-docs/certification/important-instructions-cks)
+apt-get install -y jq
+snap install yq
+
+
 ### disable linux swap and remove any existing swap partitions
 swapoff -a
 sed -i '/\sswap\s/ s/^\(.*\)$/#\1/g' /etc/fstab


### PR DESCRIPTION
The current CKS course content utilizes an online/web JSON formater, however this isn't an allowed resource during the CKS exam.

Per the CNCF exam documeation at https://docs.linuxfoundation.org/tc-docs/certification/important-instructions-cks:
	"For your convenience, all environments, in other words, the base system and the cluster nodes, have the following additional command-line tools pre-installed and pre-configured: ... yq and jq for YAML/JSON processing ..."

Thus using yq/jq during study is beneficial so include them in the cluster install scripts.

Additional links that would be useful in the relevant course resources.txt file:
	https://mikefarah.gitbook.io/yq/
	https://stedolan.github.io/jq/

Note: yq is provided as a snap in 20.04, but not available in 18.04 so these changes as-is only work against the new 20.04 scripts.
