### PR TITLE
etcdctl installation on master: Download for correct system architecture

### DIFF
--- a/cluster-setup/latest/install_master.sh
+++ b/cluster-setup/latest/install_master.sh
@@ -162,9 +162,10 @@ kubectl apply -f https://raw.githubusercontent.com/killer-sh/cks-course-environm
 
 # etcdctl
 ETCDCTL_VERSION=v3.5.1
-ETCDCTL_VERSION_FULL=etcd-${ETCDCTL_VERSION}-linux-amd64
+ETCDCTL_ARCH=$(dpkg --print-architecture)
+ETCDCTL_VERSION_FULL=etcd-${ETCDCTL_VERSION}-linux-${ETCDCTL_ARCH}
 wget https://github.com/etcd-io/etcd/releases/download/${ETCDCTL_VERSION}/${ETCDCTL_VERSION_FULL}.tar.gz
-tar xzf ${ETCDCTL_VERSION_FULL}.tar.gz
+tar xzf ${ETCDCTL_VERSION_FULL}.tar.gz ${ETCDCTL_VERSION_FULL}/etcdctl
 mv ${ETCDCTL_VERSION_FULL}/etcdctl /usr/bin/
 rm -rf ${ETCDCTL_VERSION_FULL} ${ETCDCTL_VERSION_FULL}.tar.gz
 


### PR DESCRIPTION
TL;DR Script now works on Ubuntu 20.04 VM on MacBook Pro with M1

The script worked very nicely in a Ubuntu VM on a MacBook Pro with M1. That is, until I made to section 16 in the CKS course. I noticed that etcdctl on my node 'controlplane' was for amd64 (-bash: /usr/bin/etcdctl: cannot execute binary file: Exec format error). Albeit a little outside the scope for the course (as most folks will probably not use a set of local VMs), this change now accounts for the build architecture of the master node. Thank you for the excellent CKS course!