### PR TITLE
fix: change sources list from https to http

### DIFF
--- a/cluster-setup/latest/install_master.sh
+++ b/cluster-setup/latest/install_master.sh
@@ -50,8 +50,8 @@ systemctl daemon-reload
 
 ### install podman
 . /etc/os-release
-echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:testing.list
-curl -L "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key" | sudo apt-key add -
+echo "deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:testing.list
+curl -L "http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key" | sudo apt-key add -
 apt-get update -qq
 apt-get -qq -y install podman cri-tools containers-common
 rm /etc/apt/sources.list.d/devel:kubic:libcontainers:testing.list

--- a/cluster-setup/latest/install_worker.sh
+++ b/cluster-setup/latest/install_worker.sh
@@ -50,8 +50,8 @@ systemctl daemon-reload
 
 ### install podman
 . /etc/os-release
-echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:testing.list
-curl -L "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key" | sudo apt-key add -
+echo "deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:testing.list
+curl -L "http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key" | sudo apt-key add -
 apt-get update -qq
 apt-get -qq -y install podman cri-tools containers-common
 rm /etc/apt/sources.list.d/devel:kubic:libcontainers:testing.list


### PR DESCRIPTION
Hello,

I am trying to follow the instructions via the cks course and i encounter issues with installation on both master and worker node scripts.

![image](https://github.com/killer-sh/cks-course-environment/assets/20451028/6d60d442-7e60-4a76-8f0e-0d1ab04887d0)

Apparently, this is a recent issue raised on podman repository: https://github.com/containers/podman/issues/20690

and the solution is mentioned here: https://github.com/containers/podman/issues/20690#issuecomment-1811705435

I created a PR to reflect these changes and tested to be working with the following results:

for cks-master:
![image](https://github.com/killer-sh/cks-course-environment/assets/20451028/c4f3c47d-ca43-4725-98ae-059cc9139af3)


for cks-worker:
![image](https://github.com/killer-sh/cks-course-environment/assets/20451028/1a0734f7-d833-444c-a521-eb8b0ccf7c5b)
