### PR TITLE
fix: Cluster setup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ sudo -i
 wget -qO- https://raw.githubusercontent.com/killer-sh/cks-course-environment/master/cluster-setup/latest/install_master.sh | bash
 ```
 
+you can optionally set the `POD_NETWORK_CIDR` env var (like `export POD_NETWORK_CIDR="172.16.0.0/12"`) to change the Pod network from the default CIDR of `192.168.0.0/16`.
+
 ### Setup cks-worker
 
 #### Create VM

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ gcloud compute instances create cks-master --zone=europe-west3-c \
 #### Configure
 ```
 sudo -i
-bash <(curl -s https://raw.githubusercontent.com/killer-sh/cks-course-environment/master/cluster-setup/latest/install_master.sh)
+wget -qO- https://raw.githubusercontent.com/killer-sh/cks-course-environment/master/cluster-setup/latest/install_master.sh | bash
 ```
 
 ### Setup cks-worker
@@ -68,7 +68,7 @@ gcloud compute instances create cks-worker --zone=europe-west3-c \
 #### Configure
 ```
 sudo -i
-bash <(curl -s https://raw.githubusercontent.com/killer-sh/cks-course-environment/master/cluster-setup/latest/install_worker.sh)
+wget -qO- https://raw.githubusercontent.com/killer-sh/cks-course-environment/master/cluster-setup/latest/install_worker.sh | bash
 ```
 
 ### Connect to cluster

--- a/cluster-setup/latest/install_worker.sh
+++ b/cluster-setup/latest/install_worker.sh
@@ -1,8 +1,13 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Source: http://kubernetes.io/docs/getting-started-guides/kubeadm
 
 set -e
+
+if [ "$UID" -ne 0 ]; then
+    echo "This script must be executed as root. Exiting."
+    exit 1
+fi
 
 source /etc/lsb-release
 if [ "$DISTRIB_RELEASE" != "20.04" ]; then
@@ -33,7 +38,7 @@ fi
 
 ### setup terminal
 apt-get --allow-unauthenticated update
-apt-get --allow-unauthenticated install -y bash-completion binutils
+apt-get --allow-unauthenticated install -y bash-completion binutils curl
 echo 'colorscheme ron' >> ~/.vimrc
 echo 'set tabstop=2' >> ~/.vimrc
 echo 'set shiftwidth=2' >> ~/.vimrc
@@ -62,8 +67,8 @@ systemctl daemon-reload
 
 ### install podman
 . /etc/os-release
-echo "deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:testing.list
-curl -L "http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key" | sudo apt-key add -
+echo "deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${DISTRIB_RELEASE}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:testing.list
+curl -L "http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${DISTRIB_RELEASE}/Release.key" | sudo apt-key add -
 apt-get update -qq
 apt-get -qq -y install podman cri-tools containers-common
 rm /etc/apt/sources.list.d/devel:kubic:libcontainers:testing.list


### PR DESCRIPTION
A few fixes:
- by default `curl` is not present in `Ubuntu 20.04.6 LTS`. Changed references to use `wget` by default and install the `curl` package as part of the init
- sources add failed because of a `VERSION_ID` var unset (replaced with `DISTRIB_RELEASE`)
- allow override of the pod network CIDR as I was using the same network subnet
- enforce bash usage over sh, and check we're running as root